### PR TITLE
feat: integrate theme provider

### DIFF
--- a/packages/components/src/providers/ThemeProvider/ThemeProvider.tsx
+++ b/packages/components/src/providers/ThemeProvider/ThemeProvider.tsx
@@ -1,0 +1,20 @@
+import { createContext, useState } from "react";
+
+interface ThemeProviderProps {
+  children: React.ReactNode;
+}
+
+export const ThemeContext = createContext({});
+
+export const ThemeProvider = ({ children }: ThemeProviderProps) => {
+  const [currentTheme, setCurrentTheme] = useState("light");
+
+  const toggleTheme = () => {
+    setCurrentTheme((prevTheme) => (prevTheme === "light" ? "dark" : "light"));
+  };
+  return (
+    <ThemeContext.Provider value={{ theme: currentTheme, toggleTheme }}>
+      {children}
+    </ThemeContext.Provider>
+  );
+};

--- a/packages/components/src/providers/ThemeProvider/index.ts
+++ b/packages/components/src/providers/ThemeProvider/index.ts
@@ -1,0 +1,2 @@
+export * from "./ThemeProvider";
+export * from "./useTheme";

--- a/packages/components/src/providers/ThemeProvider/useTheme.tsx
+++ b/packages/components/src/providers/ThemeProvider/useTheme.tsx
@@ -1,0 +1,10 @@
+import { useContext } from "react";
+import { ThemeContext } from "./ThemeProvider";
+
+export const useTheme = () => {
+  const context = useContext(ThemeContext);
+  if (!context) {
+    throw new Error("useTheme must be used within a ThemeProvider");
+  }
+  return context;
+};


### PR DESCRIPTION
- Added theme provider support with get and set methods for theme properties
- this theme provider will wrap the base app component 
- the setter will be used for theme switcher 
- the getter will be used to pass to the root theme provider or any custom providers on top of custom elements